### PR TITLE
Make runs only on changed pp files

### DIFF
--- a/lib/guard/puppet-lint/templates/Guardfile
+++ b/lib/guard/puppet-lint/templates/Guardfile
@@ -2,6 +2,6 @@
 #   watch(%r{file/path}) { `command(s)` }
 #
 guard 'puppet-lint' do
-  watch(/(.*).pp/) {|m| `echo #{m[0]}; \
+  watch(/(.*).pp$/) {|m| `echo #{m[0]}; \
 	puppet-lint #{m[0]} --no-80chars-check --with-filename` }
 end


### PR DESCRIPTION
Hi @alister,

I added a tiny fix in your regexp to prevent runs on files like 'modules/jenkins/manifests/.config.pp.swp'.

Cheers,

Daniel
