### PR TITLE
show notifications

### DIFF
--- a/lib/guard-puppet-lint.rb
+++ b/lib/guard-puppet-lint.rb
@@ -1,0 +1,1 @@
+require 'guard/puppet-lint'

--- a/lib/guard/puppet-lint.rb
+++ b/lib/guard/puppet-lint.rb
@@ -38,6 +38,7 @@ module Guard
     def run_on_change(res)
       messages = []
       res.each do |file|
+        file = File.join( options[:watchdir].to_s,file ) if options[:watchdir]
         @linter.file = file
         @linter.clear_messages
         @linter.run

--- a/lib/guard/puppet-lint.rb
+++ b/lib/guard/puppet-lint.rb
@@ -20,6 +20,7 @@ module Guard
   class Puppetlint < Guard
 
     def initialize(watchers = [], options = {})
+      options = { :syntax_check => true }.merge(options)
       @linter = PuppetLint.new
       super
     end
@@ -48,11 +49,13 @@ module Guard
       res.each do |file|
         file = File.join( options[:watchdir].to_s,file ) if options[:watchdir]
 
-        parser_messages = `puppet parser validate #{file} --color=false`.split("\n")
-        parser_messages.reject! { |s| s =~ /puppet help parser validate/ }
-        parser_messages.map! { |s| s.gsub 'err: Could not parse for environment production:', '' }
+        if options[:syntax_check]
+          parser_messages = `puppet parser validate #{file} --color=false`.split("\n")
+          parser_messages.reject! { |s| s =~ /puppet help parser validate/ }
+          parser_messages.map! { |s| s.gsub 'err: Could not parse for environment production:', '' }
 
-        messages += prepend_filename(parser_messages, file)
+          messages += prepend_filename(parser_messages, file)
+        end
 
         @linter.file = file
         @linter.clear_messages

--- a/lib/guard/puppet-lint.rb
+++ b/lib/guard/puppet-lint.rb
@@ -34,16 +34,31 @@ module Guard
       run_on_change(Watcher.match_files(self, Dir.glob('{,**/}*{,.*}').uniq))
     end
 
+    def prepend_filename(msg, file)
+      if msg
+        msg.map {|x| "#{file}: #{x}"}
+      else
+        []
+      end
+    end
+
     # Print the result of the command(s), if there are results to be printed.
     def run_on_change(res)
       messages = []
       res.each do |file|
         file = File.join( options[:watchdir].to_s,file ) if options[:watchdir]
+
+        parser_messages = `puppet parser validate #{file} --color=false`.split("\n")
+        parser_messages.reject! { |s| s =~ /puppet help parser validate/ }
+        parser_messages.map! { |s| s.gsub 'err: Could not parse for environment production:', '' }
+
+        messages += prepend_filename(parser_messages, file)
+
         @linter.file = file
         @linter.clear_messages
         @linter.run
         linter_msg = @linter.messages.reject { |s| !options[:show_warnings] && s =~ /WARNING/ }
-        messages += linter_msg.map {|x| "#{file}: #{x}"} if linter_msg
+        messages += prepend_filename(linter_msg, file)
       end
       if messages.empty?
         messages = ["Files are ok:"] + res

--- a/lib/guard/puppet-lint.rb
+++ b/lib/guard/puppet-lint.rb
@@ -44,7 +44,13 @@ module Guard
         linter_msg = @linter.messages.reject { |s| !options[:show_warnings] && s =~ /WARNING/ }
         messages += linter_msg.map {|x| "#{file}: #{x}"} if linter_msg
       end
-      Notifier.notify( messages.join("\n"), :title => "Puppet lint", :image => :failed )
+      if messages.empty?
+        messages = ["Files are ok:"] + res
+        image = :success
+      else
+        image = :failed
+      end
+      Notifier.notify( messages.join("\n"), :title => "Puppet lint", :image => image )
     end
   end
 end

--- a/lib/guard/puppet-lint.rb
+++ b/lib/guard/puppet-lint.rb
@@ -1,11 +1,28 @@
 require 'guard'
 require 'guard/guard'
 require 'guard/watcher'
+require 'puppet-lint'
+
+class PuppetLint
+
+  attr_reader :messages
+
+  def clear_messages
+    @messages = []
+  end
+
+  def format_message(message)
+    @messages << (log_format % message)
+  end
+end
 
 module Guard
   class Puppetlint < Guard
 
-    VERSION = '0.0.1'
+    def initialize(watchers = [], options = {})
+      @linter = PuppetLint.new
+      super
+    end
 
     # Calls #run_all if the :all_on_start option is present.
     def start
@@ -19,15 +36,15 @@ module Guard
 
     # Print the result of the command(s), if there are results to be printed.
     def run_on_change(res)
-      puts res if res
-    end
-
-  end
-
-  class Dsl
-    # Easy method to display a notification
-    def n(msg, title='', image=nil)
-      Notifier.notify(msg, :title => title, :image => image)
+      messages = []
+      res.each do |file|
+        @linter.file = file
+        @linter.clear_messages
+        @linter.run
+        linter_msg = @linter.messages.reject { |s| !options[:show_warnings] && s =~ /WARNING/ }
+        messages += linter_msg.map {|x| "#{file}: #{x}"} if linter_msg
+      end
+      Notifier.notify( messages.join("\n"), :title => "Puppet lint", :image => :failed )
     end
   end
 end

--- a/lib/guard/puppet-lint/templates/Guardfile
+++ b/lib/guard/puppet-lint/templates/Guardfile
@@ -1,6 +1,9 @@
 # Add files and commands to this file, like the example:
 #   watch(%r{file/path}) { `command(s)` }
 #
-guard 'puppet-lint', :show_warnings => false, :watchdir => Guard.options[:watchdir] do
+guard 'puppet-lint', :watchdir => Guard.options[:watchdir], 
+                     :show_warnings => false, 
+                     :syntax_check => true \
+do
   watch(/(.*).pp$/)
 end

--- a/lib/guard/puppet-lint/templates/Guardfile
+++ b/lib/guard/puppet-lint/templates/Guardfile
@@ -1,6 +1,6 @@
 # Add files and commands to this file, like the example:
 #   watch(%r{file/path}) { `command(s)` }
 #
-guard 'puppet-lint' do
+guard 'puppet-lint', :show_warnings => false do
   watch(/(.*).pp$/)
 end

--- a/lib/guard/puppet-lint/templates/Guardfile
+++ b/lib/guard/puppet-lint/templates/Guardfile
@@ -2,6 +2,5 @@
 #   watch(%r{file/path}) { `command(s)` }
 #
 guard 'puppet-lint' do
-  watch(/(.*).pp$/) {|m| `echo #{m[0]}; \
-	puppet-lint #{m[0]} --no-80chars-check --with-filename` }
+  watch(/(.*).pp$/)
 end

--- a/lib/guard/puppet-lint/templates/Guardfile
+++ b/lib/guard/puppet-lint/templates/Guardfile
@@ -1,6 +1,6 @@
 # Add files and commands to this file, like the example:
 #   watch(%r{file/path}) { `command(s)` }
 #
-guard 'puppet-lint', :show_warnings => false do
+guard 'puppet-lint', :show_warnings => false, :watchdir => Guard.options[:watchdir] do
   watch(/(.*).pp$/)
 end


### PR DESCRIPTION
Use guard's notifier to show popup messages.

Several notes:
- puppet-lint is monkey-patched a little bit. This may break in future puppet-lint versions
- Guardfile syntax is no longer compatible with previous version of guard-puppet-lint — you'll need to recreate it
- by default messages for errors are showed only and no messages for warnings. You'll  need to pass variable show_warnings to guard definition (there is an example in templated guardfile of how to do that)
